### PR TITLE
[test] Should not throw when data is undefined

### DIFF
--- a/lib/result.spec.js
+++ b/lib/result.spec.js
@@ -117,6 +117,19 @@ describe('Result', function () {
     chai.expect(result.get().baz, 'added key').to.equal(undefined);
   });
 
+  it('should not throw when data is undefined', function () {
+    const data = undefined;
+
+    const observer = {
+      subscribe({ next }) {
+        next({ data, loading: true, networkStatus: 1, stale: true });
+      },
+    };
+
+    const result = new Result({ observer });
+    chai.expect(result.get(), 'result value').to.equal(undefined);
+  });
+
   describe('#then', function () {
     it('should return a promise', function () {
       const observer = {


### PR DESCRIPTION
When calling Template.gqlQuery, apollo-client will dispatch
an `APOLLO_QUERY_INIT` action to the redux store, resulting in
the invocation of the query subscription established by the
`Result` class.

apollo provides an undefined value as the data parameter to
`next` function. Thus, any call to `Result::get` will throw
until the real data arrives from the server.